### PR TITLE
fix: support 2 type SSL cert (gcp / external)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,5 @@ Author Information
 [amazon.aws]: https://github.com/ansible-collections/amazon.aws
 [google.cloud]: https://github.com/ansible-collections/google.cloud
 [microsoft.azure]: https://github.com/ansible-collections/azure
+[hetzner.hcloud]: https://github.com/ansible-collections/hetzner.hcloud
+[community.digitalocean]: https://github.com/ansible-collections/community.digitalocean

--- a/tasks/gcp/certificate/external-certificate.yml
+++ b/tasks/gcp/certificate/external-certificate.yml
@@ -1,10 +1,10 @@
 ---  
 - name: Create a External SSL Certificate
   google.cloud.gcp_compute_ssl_certificate:
-    name: "{{ cloud_provider_resource_detail.cert_name }}"
-    description: "{{ cloud_provider_resource_detail.cert_description }}"
-    certificate: "{{ cloud_provider_resource_detail.cert_pem | default('') }}"
-    private_key: "{{ cloud_provider_resource_detail.cert_private | default('') }}"
+    name: "{{ cloud_provider_resource_detail.certificate_name }}"
+    description: "{{ cloud_provider_resource_detail.certificate_description }}"
+    certificate: "{{ cloud_provider_resource_detail.certificate_pem | default('') }}"
+    private_key: "{{ cloud_provider_resource_detail.certificate_private | default('') }}"
     project: "{{ cloud_provider_auth.project_id }}"
     auth_kind: "{{ cloud_provider_auth.auth_kind }}"
     service_account_file: "{{ cloud_provider_auth.service_acount_token }}"

--- a/tasks/gcp/certificate/external-certificate.yml
+++ b/tasks/gcp/certificate/external-certificate.yml
@@ -1,5 +1,5 @@
 ---  
-- name: Create a External SSL Certificate
+- name: Manage a External SSL Certificate
   google.cloud.gcp_compute_ssl_certificate:
     name: "{{ cloud_provider_resource_detail.certificate_name }}"
     description: "{{ cloud_provider_resource_detail.certificate_description }}"

--- a/tasks/gcp/certificate/external-certificate.yml
+++ b/tasks/gcp/certificate/external-certificate.yml
@@ -1,10 +1,10 @@
----
+---  
 - name: Create a External SSL Certificate
   google.cloud.gcp_compute_ssl_certificate:
     name: "{{ cloud_provider_resource_detail.cert_name }}"
     description: "{{ cloud_provider_resource_detail.cert_description }}"
-    certificate: "{{ cloud_provider_resource_detail.cert_pem }}" 
-    private_key: "{{ cloud_provider_resource_detail.cert_private }}" 
+    certificate: "{{ cloud_provider_resource_detail.cert_pem | default('') }}"
+    private_key: "{{ cloud_provider_resource_detail.cert_private | default('') }}"
     project: "{{ cloud_provider_auth.project_id }}"
     auth_kind: "{{ cloud_provider_auth.auth_kind }}"
     service_account_file: "{{ cloud_provider_auth.service_acount_token }}"

--- a/tasks/gcp/certificate/main.yml
+++ b/tasks/gcp/certificate/main.yml
@@ -1,3 +1,3 @@
 ---
   - name: Include Certificate Type
-    ansible.builtin.include_tasks: "{{ cloud_provider_resource_detail.certificate_type }}.yml"
+    ansible.builtin.include_tasks: "{{ cloud_provider_resource_detail.certificate_type }}-certificate.yml"

--- a/tasks/gcp/certificate/main.yml
+++ b/tasks/gcp/certificate/main.yml
@@ -1,0 +1,3 @@
+---
+  - name: Include Certificate Type
+    ansible.builtin.include_tasks: "{{ cloud_provider_resource_detail.certificate_type }}.yml"

--- a/tasks/gcp/certificate/managed-certificate.yml
+++ b/tasks/gcp/certificate/managed-certificate.yml
@@ -1,10 +1,10 @@
 ---
 - name: Create a GCP Managed SSL Certificate
   google.cloud.gcp_compute_ssl_certificate:
-    name: "{{ cloud_provider_resource_detail.cert_name }}"
-    description: "{{ cloud_provider_resource_detail.cert_description }}"
+    name: "{{ cloud_provider_resource_detail.certificate_name }}"
+    description: "{{ cloud_provider_resource_detail.certificate_description }}"
     type: "MANAGED"
-    managed: "{{ cloud_provider_resource_detail.cert_managed }}"
+    managed: "{{ cloud_provider_resource_detail.certificate_managed }}"
     project: "{{ cloud_provider_auth.project_id }}"
     auth_kind: "{{ cloud_provider_auth.auth_kind }}"
     service_account_file: "{{ cloud_provider_auth.service_acount_token }}"

--- a/tasks/gcp/certificate/managed-certificate.yml
+++ b/tasks/gcp/certificate/managed-certificate.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create a GCP Managed SSL Certificate
+- name: Manage a Google-managed SSL Certificate
   google.cloud.gcp_compute_ssl_certificate:
     name: "{{ cloud_provider_resource_detail.certificate_name }}"
     description: "{{ cloud_provider_resource_detail.certificate_description }}"

--- a/tasks/gcp/certificate/managed-certificate.yml
+++ b/tasks/gcp/certificate/managed-certificate.yml
@@ -1,0 +1,11 @@
+---
+- name: Create a GCP Managed SSL Certificate
+  google.cloud.gcp_compute_ssl_certificate:
+    name: "{{ cloud_provider_resource_detail.cert_name }}"
+    description: "{{ cloud_provider_resource_detail.cert_description }}"
+    type: "MANAGED"
+    managed: "{{ cloud_provider_resource_detail.cert_managed }}"
+    project: "{{ cloud_provider_auth.project_id }}"
+    auth_kind: "{{ cloud_provider_auth.auth_kind }}"
+    service_account_file: "{{ cloud_provider_auth.service_acount_token }}"
+    state: "{{ cloud_provider_resource_detail.state | default('present') }}"

--- a/tasks/gcp/certificate/self-certificate.yml
+++ b/tasks/gcp/certificate/self-certificate.yml
@@ -1,0 +1,11 @@
+---
+- name: Create a External SSL Certificate
+  google.cloud.gcp_compute_ssl_certificate:
+    name: "{{ cloud_provider_resource_detail.cert_name }}"
+    description: "{{ cloud_provider_resource_detail.cert_description }}"
+    certificate: "{{ cloud_provider_resource_detail.cert_pem }}" 
+    private_key: "{{ cloud_provider_resource_detail.cert_private }}" 
+    project: "{{ cloud_provider_auth.project_id }}"
+    auth_kind: "{{ cloud_provider_auth.auth_kind }}"
+    service_account_file: "{{ cloud_provider_auth.service_acount_token }}"
+    state: "{{ cloud_provider_resource_detail.state | default('present') }}"

--- a/tasks/gcp/load-balancer/README.md
+++ b/tasks/gcp/load-balancer/README.md
@@ -6,3 +6,4 @@ Manage Google Cloud Platform Load Balancer
 # References
 
 - [URL Map Configuration](https://github.com/ansible-collections/google.cloud/issues/571)
+- [Regional Map URL](https://github.com/ansible-collections/google.cloud/issues/573)


### PR DESCRIPTION
## Description

Create GCP certificate, you can create Google-managed certificate or external certificate, this PR depend to https://github.com/ansible-collections/google.cloud/pull/672

### Google-managed SSL

```yml
---

- name: Create Google-managed SSL Certificate
  hosts: localhost
  gather_facts: false
  
  vars:
    cloud_provider: "gcp"
    cloud_provider_resource_type: "certificate"
    cloud_provider_auth:
      project_id: "terpusat"
      auth_kind: "serviceaccount"
      service_acount_token: "../credential.json"
    cloud_provider_resource_detail:
      # certificate parameters
      certificate_type: "managed"
      cert_name: "cert-dpanel-example"
      cert_description: "Certificate for gcp.terpusat.me"
      cert_managed:
        domains:
        - gcp.terpusat.me
      state: "present"

  roles:
    - role: dpanel.cloud-provider

```